### PR TITLE
[fix] dash dependancies + python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ setup(
         'cython',
         'scipy',
         'dash_daq',
-        'dash_bootstrap_components'
+        'dash_bootstrap_components',
+        'dash<3.0' 
         ],
         extras_require={
             'dev': ['pytest']}


### PR DESCRIPTION
I changed just the setup for another previous Dash version and it worked. 
Its just a simple line!
